### PR TITLE
feat: Add pagination to customer order history

### DIFF
--- a/app/Http/Controllers/Web/Operator/CustomerController.php
+++ b/app/Http/Controllers/Web/Operator/CustomerController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Authenticate;
 use App\Models\LineUser;
 use App\Models\Operator;
-use App\Models\Order;
+use App\Models\Order; // 念のため確認、なければ追加
 use App\Models\User;
 use App\Services\Customer\Queries\GetCustomerListQuery;
 use App\Services\Customer\CustomerRegistrationService;
@@ -137,7 +137,12 @@ class CustomerController extends Controller
         // LINE連携情報を取得
         $lineUser = LineUser::where('user_id', $user->id)->first();
 
-        return view('operator.customer.show', compact('operator', 'user', 'authenticate', 'lineUser'));
+        // 顧客の注文履歴を取得（作成日時の降順、ページネーション付き）
+        $orders = Order::where('user_id', $user->id)
+                       ->orderBy('created_at', 'desc')
+                       ->paginate(10); // 1ページあたり10件表示
+
+        return view('operator.customer.show', compact('operator', 'user', 'authenticate', 'lineUser', 'orders'));
     }
 
     /**

--- a/resources/views/components/operator/widgets/customer/order-history-component.blade.php
+++ b/resources/views/components/operator/widgets/customer/order-history-component.blade.php
@@ -45,6 +45,11 @@
                         @endforeach
                     </tbody>
                 </table>
+
+                {{-- ページネーションリンク --}}
+                <div class="mt-4">
+                    {{ $orders->links() }}
+                </div>
             @endif
         </div>
     </div>

--- a/resources/views/operator/customer/show.blade.php
+++ b/resources/views/operator/customer/show.blade.php
@@ -21,9 +21,10 @@
                             {{-- 注文履歴コンポーネント --}}
                             <div class="flex-grow-[2] min-h-0">
                                 <x-operator.widgets.customer.order-history-component
-                                    :user="$user" />
+                                    :user="$user"
+                                    :orders="$orders" /> {{-- $orders をコンポーネントに渡す --}}
                             </div>
-                            {{-- LINEメッセージフォーム�ンポーネント --}}
+                            {{-- LINEメッセージフォームンポーネント --}}
                             @once
                                 <div class="flex-grow-[1] min-h-0">
                                     <x-operator.widgets.customer.line-message-form-component


### PR DESCRIPTION
顧客詳細画面の注文履歴にページネーションを追加しました。

- `CustomerController` で注文履歴をページネートするように変更。
- `show.blade.php` でページネーションリンクを表示するように変更。
- `order-history-component.blade.php` でページネーションリンクを表示するように変更。