### PR TITLE
Fix item update unit_id error

### DIFF
--- a/app/Services/Item/ItemUpdateService.php
+++ b/app/Services/Item/ItemUpdateService.php
@@ -30,6 +30,7 @@ class ItemUpdateService
                     Rule::unique('items')->ignore($itemId)
                 ],
                 'category_id' => ['required', 'exists:item_categories,id'],
+                'unit_id' => ['required', 'exists:item_units,id'],
                 'name' => ['required', 'string', 'max:64'],
                 'description' => ['nullable', 'string'],
                 'is_recommended' => ['nullable', 'in:0,1'],
@@ -42,6 +43,8 @@ class ItemUpdateService
                 'item_code.unique' => 'この商品コードは既に使用されています。',
                 'category_id.required' => 'カテゴリーは必須です。',
                 'category_id.exists' => '選択されたカテゴリーは存在しません。',
+                'unit_id.required' => '単位は必須です。',
+                'unit_id.exists' => '選択された単位は存在しません。',
                 'name.required' => '商品名は必須です。',
                 'name.max' => '商品名は64文字以内で入力してください。',
                 'is_recommended.in' => 'おすすめフラグの値が不正です。',


### PR DESCRIPTION
商品更新時の unit_id に関するバリデーションエラーを修正しました。

具体的には、以下の対応を行いました。
1. `app/Services/Item/ItemUpdateService.php` に `unit_id` の存在チェックバリデーションを追加。
2. クライアント要件で商品編集時に `unit_id` が隠しフィールドで `1` に固定されていた問題に対し、`item_units` テーブルに `id=1` となるデフォルト単位 (`unit_code='NO_UNIT'`, `name='未設定'`) を登録。