### PR TITLE
Fix: 管理者向け注文通知メールの送信先と内容を修正

### DIFF
--- a/app/Listeners/SendOrderNotification.php
+++ b/app/Listeners/SendOrderNotification.php
@@ -27,27 +27,19 @@ class SendOrderNotification // Potentially implements ShouldQueue later
      */
     public function handle(OrderCreated $event): void
     {
-        \Log::debug('[SendOrderNotification] Handle method called.'); // Changed to debug level
         $order = $event->order;
         $customer = $order->customer; // Assuming relation exists
 
         // Send email to customer
         if ($customer && $customer->email) {
-            \Log::debug('[SendOrderNotification] Attempting to send email to customer: ' . $customer->email); // Changed to debug level
             Mail::to($customer->email)->send(new OrderCompletedForCustomer($order));
-            \Log::debug('[SendOrderNotification] Email to customer sent (or queued).'); // Changed to debug level
-        } else {
-            \Log::debug('[SendOrderNotification] Customer email not found or customer does not exist. Skipping customer email.'); // Changed to debug level
         }
 
         // Send email to operators
         $operatorEmail = config('mail.operator_notification_address');
-        \Log::debug('[SendOrderNotification] Operator notification email from config: \'' . $operatorEmail . '\''); // Changed to debug level
 
         if ($this->isValidOperatorEmail($operatorEmail)) {
-            \Log::debug('[SendOrderNotification] Attempting to send email to operator: ' . $operatorEmail); // Changed to debug level
             Mail::to($operatorEmail)->send(new OrderNotificationForOperator($order));
-            \Log::debug('[SendOrderNotification] Email to operator sent (or queued).'); // Changed to debug level
         } else {
             // Keep error log as error level
             \Log::error('[SendOrderNotification] Operator notification email is not configured, invalid, or is the default fallback. Email not sent. Value: \'' . $operatorEmail . '\'');

--- a/app/Listeners/SendOrderNotification.php
+++ b/app/Listeners/SendOrderNotification.php
@@ -63,9 +63,7 @@ class SendOrderNotification // Potentially implements ShouldQueue later
     {
         // Check if the email is not empty, is a valid email format,
         // and is not the default fallback email address.
-        $fallbackEmail = config('mail.from.address', 'your-default-fallback-email@example.com'); // Default fallback from general mail config
-        // More specific fallback for operator_notification_address if defined differently,
-        // but we used 'your-default-fallback-email@example.com' in its definition.
+        // $fallbackEmail variable was unused.
         $operatorConfigFallback = self::DEFAULT_FALLBACK_EMAIL;
 
         return !empty($email) &&

--- a/app/Listeners/SendOrderNotification.php
+++ b/app/Listeners/SendOrderNotification.php
@@ -27,28 +27,29 @@ class SendOrderNotification // Potentially implements ShouldQueue later
      */
     public function handle(OrderCreated $event): void
     {
-        \Log::info('[SendOrderNotification] Handle method called.');
+        \Log::debug('[SendOrderNotification] Handle method called.'); // Changed to debug level
         $order = $event->order;
         $customer = $order->customer; // Assuming relation exists
 
         // Send email to customer
         if ($customer && $customer->email) {
-            \Log::info('[SendOrderNotification] Attempting to send email to customer: ' . $customer->email);
+            \Log::debug('[SendOrderNotification] Attempting to send email to customer: ' . $customer->email); // Changed to debug level
             Mail::to($customer->email)->send(new OrderCompletedForCustomer($order));
-            \Log::info('[SendOrderNotification] Email to customer sent (or queued).');
+            \Log::debug('[SendOrderNotification] Email to customer sent (or queued).'); // Changed to debug level
         } else {
-            \Log::info('[SendOrderNotification] Customer email not found or customer does not exist. Skipping customer email.');
+            \Log::debug('[SendOrderNotification] Customer email not found or customer does not exist. Skipping customer email.'); // Changed to debug level
         }
 
         // Send email to operators
         $operatorEmail = config('mail.operator_notification_address');
-        \Log::info('[SendOrderNotification] Operator notification email from config: \'' . $operatorEmail . '\'');
+        \Log::debug('[SendOrderNotification] Operator notification email from config: \'' . $operatorEmail . '\''); // Changed to debug level
 
         if ($this->isValidOperatorEmail($operatorEmail)) {
-            \Log::info('[SendOrderNotification] Attempting to send email to operator: ' . $operatorEmail);
+            \Log::debug('[SendOrderNotification] Attempting to send email to operator: ' . $operatorEmail); // Changed to debug level
             Mail::to($operatorEmail)->send(new OrderNotificationForOperator($order));
-            \Log::info('[SendOrderNotification] Email to operator sent (or queued).');
+            \Log::debug('[SendOrderNotification] Email to operator sent (or queued).'); // Changed to debug level
         } else {
+            // Keep error log as error level
             \Log::error('[SendOrderNotification] Operator notification email is not configured, invalid, or is the default fallback. Email not sent. Value: \'' . $operatorEmail . '\'');
         }
     }

--- a/app/Listeners/SendOrderNotification.php
+++ b/app/Listeners/SendOrderNotification.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\Mail;
 
 class SendOrderNotification // Potentially implements ShouldQueue later
 {
+    private const DEFAULT_FALLBACK_EMAIL = 'your-default-fallback-email@example.com';
+
     /**
      * Create the event listener.
      */
@@ -64,7 +66,7 @@ class SendOrderNotification // Potentially implements ShouldQueue later
         $fallbackEmail = config('mail.from.address', 'your-default-fallback-email@example.com'); // Default fallback from general mail config
         // More specific fallback for operator_notification_address if defined differently,
         // but we used 'your-default-fallback-email@example.com' in its definition.
-        $operatorConfigFallback = 'your-default-fallback-email@example.com';
+        $operatorConfigFallback = self::DEFAULT_FALLBACK_EMAIL;
 
         return !empty($email) &&
                filter_var($email, FILTER_VALIDATE_EMAIL) &&

--- a/app/Listeners/SendOrderNotification.php
+++ b/app/Listeners/SendOrderNotification.php
@@ -42,12 +42,32 @@ class SendOrderNotification // Potentially implements ShouldQueue later
         $operatorEmail = config('mail.operator_notification_address');
         \Log::info('[SendOrderNotification] Operator notification email from config: \'' . $operatorEmail . '\'');
 
-        if ($operatorEmail && filter_var($operatorEmail, FILTER_VALIDATE_EMAIL) && $operatorEmail !== 'your-default-fallback-email@example.com') {
+        if ($this->isValidOperatorEmail($operatorEmail)) {
             \Log::info('[SendOrderNotification] Attempting to send email to operator: ' . $operatorEmail);
             Mail::to($operatorEmail)->send(new OrderNotificationForOperator($order));
             \Log::info('[SendOrderNotification] Email to operator sent (or queued).');
         } else {
             \Log::error('[SendOrderNotification] Operator notification email is not configured, invalid, or is the default fallback. Email not sent. Value: \'' . $operatorEmail . '\'');
         }
+    }
+
+    /**
+     * Validate the operator email address.
+     *
+     * @param string|null $email
+     * @return boolean
+     */
+    private function isValidOperatorEmail(?string $email): bool
+    {
+        // Check if the email is not empty, is a valid email format,
+        // and is not the default fallback email address.
+        $fallbackEmail = config('mail.from.address', 'your-default-fallback-email@example.com'); // Default fallback from general mail config
+        // More specific fallback for operator_notification_address if defined differently,
+        // but we used 'your-default-fallback-email@example.com' in its definition.
+        $operatorConfigFallback = 'your-default-fallback-email@example.com';
+
+        return !empty($email) &&
+               filter_var($email, FILTER_VALIDATE_EMAIL) &&
+               $email !== $operatorConfigFallback;
     }
 }

--- a/app/Mail/OrderNotificationForOperator.php
+++ b/app/Mail/OrderNotificationForOperator.php
@@ -66,8 +66,8 @@ class OrderNotificationForOperator extends Mailable implements ShouldQueue
             // Since we *are* using Mail::to() in the listener with the correct address,
             // this `to` field in the Mailable's envelope is less critical for the primary recipient.
             // However, it's good practice for it to reflect the intended recipient if known.
-            // Since we throw an exception if $operatorEmail is missing, the ternary check is redundant.
-            to: [new Address($operatorEmail)], // $operatorEmail is guaranteed to be valid here
+            // Since the recipient is specified in the listener using Mail::to(),
+            // specifying it here is redundant and potentially confusing. Removing it.
             subject: sprintf('【%s】新規注文のお知らせ (注文ID: %s)', $siteName, $this->order->id),
         );
     }

--- a/app/Mail/OrderNotificationForOperator.php
+++ b/app/Mail/OrderNotificationForOperator.php
@@ -66,7 +66,8 @@ class OrderNotificationForOperator extends Mailable implements ShouldQueue
             // Since we *are* using Mail::to() in the listener with the correct address,
             // this `to` field in the Mailable's envelope is less critical for the primary recipient.
             // However, it's good practice for it to reflect the intended recipient if known.
-            to: $operatorEmail ? [new Address($operatorEmail)] : [], // Ensure $operatorEmail is not empty
+            // Since we throw an exception if $operatorEmail is missing, the ternary check is redundant.
+            to: [new Address($operatorEmail)], // $operatorEmail is guaranteed to be valid here
             subject: sprintf('【%s】新規注文のお知らせ (注文ID: %s)', $siteName, $this->order->id),
         );
     }

--- a/app/Mail/OrderNotificationForOperator.php
+++ b/app/Mail/OrderNotificationForOperator.php
@@ -42,20 +42,16 @@ class OrderNotificationForOperator extends Mailable implements ShouldQueue
         // The listener now handles the check for a missing operatorEmail,
         // so this Mailable assumes $operatorEmail will be valid if it reaches here.
         // However, as a safeguard or for direct Mailable usage, keeping a check can be useful.
+        // If the listener didn't catch the missing config, throw an exception here.
         if (!$operatorEmail) {
             // This case should ideally not be reached if the listener checks first.
-            // If it is, it means the Mailable is used directly without proper config.
-            \Log::critical('OrderNotificationForOperator Mailable called directly without operator_notification_address configured.');
-            // Fallback to a clearly identifiable non-production address or throw an exception
-            // For now, let's assume the listener's check is primary.
-            // If we want to ensure this Mailable is self-contained for direct use,
-            // we might throw an exception or use a very specific non-deliverable address.
-            // For this flow, we rely on the listener to not send if config is missing.
-            // Thus, $operatorEmail should be populated.
+            // Throwing an exception ensures misconfiguration doesn't lead to silent failure.
+            throw new \RuntimeException('OrderNotificationForOperator Mailable requires a valid operator_notification_address to be configured.');
         }
 
-        // If $operatorEmail could still be null/empty here and we must send *something*
-        // or prevent error, a more robust fallback or exception is needed.
+        // If $operatorEmail could still be null/empty here (e.g., empty string from config),
+        // the Address constructor might fail or lead to issues.
+        // The listener's isValidOperatorEmail should prevent this, but adding robustness here is possible.
         // Given the listener change, we expect $operatorEmail to be valid.
         // If not, Mail::to() in the listener would have already skipped sending.
         // So, the `to` field here is more of a confirmation if the Mailable itself

--- a/config/mail.php
+++ b/config/mail.php
@@ -108,6 +108,18 @@ return [
     |
     */
 
+    /*
+    |--------------------------------------------------------------------------
+    | Operator Notification Email Address
+    |--------------------------------------------------------------------------
+    |
+    | This address is used to send notifications to the operator when new
+    | orders are created. It's configured via the .env file.
+    |
+    */
+
+    'operator_notification_address' => env('OPERATOR_NOTIFICATION_EMAIL', 'your-default-fallback-email@example.com'),
+
     'from' => [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
         'name' => env('MAIL_FROM_NAME', 'Example'),

--- a/resources/views/emails/operator/order_notification.blade.php
+++ b/resources/views/emails/operator/order_notification.blade.php
@@ -1,11 +1,34 @@
 <x-mail::message>
-# Introduction
+# 新規注文のお知らせ
 
-The body of your message.
+新しい注文が入りました。詳細は以下の通りです。
 
-<x-mail::button :url="''">
-Button Text
-</x-mail::button>
+## 注文情報
+- **注文ID:** {{ $order->id }}
+- **注文日時:** {{ $order->created_at->format('Y年m月d日 H:i') }}
+@if($order->customer)
+- **顧客名:** {{ $order->customer->name ?? 'N/A' }} (ID: {{ $order->customer->id ?? 'N/A' }})
+@else
+- **顧客情報:** 登録されていません
+@endif
+
+## 注文商品
+<x-mail::table>
+| 商品名 | 単価 | 数量 | 小計 |
+| :----- | :---: | :--: | :--: |
+@if($order->orderDetails && $order->orderDetails->count() > 0)
+@foreach($order->orderDetails as $detail)
+| {{ $detail->item_name ?? ($detail->item->name ?? 'N/A') }} | ¥{{ number_format($detail->price_at_ordering ?? ($detail->item->price ?? 0)) }} | {{ $detail->quantity ?? 'N/A' }} | ¥{{ number_format(($detail->price_at_ordering ?? ($detail->item->price ?? 0)) * ($detail->quantity ?? 0)) }} |
+@endforeach
+@else
+| 商品情報がありません | - | - | - |
+@endif
+</x-mail::table>
+
+## 合計金額
+**¥{{ number_format($order->total_amount ?? 0) }}**
+
+ご確認よろしくお願いいたします。
 
 Thanks,<br>
 {{ config('app.name') }}

--- a/resources/views/emails/operator/order_notification.blade.php
+++ b/resources/views/emails/operator/order_notification.blade.php
@@ -18,7 +18,12 @@
 | :----- | :---: | :--: | :--: |
 @if($order->orderDetails && $order->orderDetails->count() > 0)
 @foreach($order->orderDetails as $detail)
-| {{ $detail->item_name ?? ($detail->item->name ?? 'N/A') }} | ¥{{ number_format($detail->price_at_ordering ?? ($detail->item->price ?? 0)) }} | {{ $detail->quantity ?? 'N/A' }} | ¥{{ number_format(($detail->price_at_ordering ?? ($detail->item->price ?? 0)) * ($detail->quantity ?? 0)) }} |
+@php
+    $price = $detail->price_at_ordering ?? ($detail->item->price ?? 0);
+    $quantity = $detail->quantity ?? 0;
+    $subtotal = $price * $quantity;
+@endphp
+| {{ $detail->item_name ?? ($detail->item->name ?? 'N/A') }} | ¥{{ number_format($price) }} | {{ $quantity }} | ¥{{ number_format($subtotal) }} |
 @endforeach
 @else
 | 商品情報がありません | - | - | - |


### PR DESCRIPTION
管理者向け注文通知メール機能に関する修正を行いました。

主な変更点:
- 通知メールの送信先を、.envファイルで指定された単一の管理者メールアドレス（OPERATOR_NOTIFICATION_EMAIL）に限定しました。
- メール本文に、注文ID、注文日時、顧客名（または顧客ID）、注文商品リスト（商品名、単価、数量、小計など）、合計金額を表示するようにしました。

これにより、管理者は注文発生時に必要な情報を迅速に把握できるようになります。