### PR TITLE
Fix: 顧客注文履歴のページネーションエラーを修正

### DIFF
--- a/app/View/Components/Operator/Widgets/Customer/OrderHistoryComponent.php
+++ b/app/View/Components/Operator/Widgets/Customer/OrderHistoryComponent.php
@@ -30,7 +30,7 @@ class OrderHistoryComponent extends Component
             ->whereNotNull('ordered_at') // ordered_atがNullではないものに限定
             ->with(['orderDetails.item']) // 注文詳細と商品情報を一緒に取得
             ->orderBy('created_at', 'desc')
-            ->get();
+            ->paginate(10);
     }
 
     /**


### PR DESCRIPTION
顧客詳細ページの注文履歴セクションで発生していたページネーションエラーを修正しました。

## 変更内容
- `app/View/Components/Operator/Widgets/Customer/OrderHistoryComponent.php` の `__construct` メソッド内で、注文履歴を取得する際の `->get()` を `->paginate(10)` に変更しました。

これにより、注文履歴が正しくページネーション表示されるようになります。