### PR TITLE
feat: 注文履歴ウィジェットで未出力の注文に詳細リンクを追加

### DIFF
--- a/resources/views/components/operator/widgets/customer/order-history-component.blade.php
+++ b/resources/views/components/operator/widgets/customer/order-history-component.blade.php
@@ -36,9 +36,9 @@
                                             出力済
                                         </span>
                                     @else
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium bg-gray-100 text-gray-800">
+                                        <a href="{{ route('operator.order.show', ['id' => $order->id]) }}" class="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium bg-gray-100 text-gray-800 hover:bg-gray-200 transition-colors duration-150">
                                             未出力
-                                        </span>
+                                        </a>
                                     @endif
                                 </td>
                             </tr>


### PR DESCRIPTION
管理者側の顧客詳細情報画面の注文詳細ウィジェットにおいて、エクスポート状態が「未出力」のデータに注文詳細画面へのリンクを追加しました。

## 変更点
- `resources/views/components/operator/widgets/customer/order-history-component.blade.php` を修正し、「未出力」の場合に注文詳細画面 (`operator.order.show`) へのリンクを表示するようにしました。