### PR TITLE
feat: Update order email templates

### DIFF
--- a/app/Mail/OrderNotificationForOperator.php
+++ b/app/Mail/OrderNotificationForOperator.php
@@ -68,7 +68,7 @@ class OrderNotificationForOperator extends Mailable implements ShouldQueue
             // However, it's good practice for it to reflect the intended recipient if known.
             // Since the recipient is specified in the listener using Mail::to(),
             // specifying it here is redundant and potentially confusing. Removing it.
-            subject: sprintf('【%s】新規注文のお知らせ (注文ID: %s)', $siteName, $this->order->id),
+            subject: sprintf('【%s】新規注文のお知らせ (注文コード: %s)', $siteName, $this->order->order_code),
         );
     }
 

--- a/resources/views/emails/customer/order_completed.blade.php
+++ b/resources/views/emails/customer/order_completed.blade.php
@@ -1,11 +1,30 @@
 <x-mail::message>
-# Introduction
+# ご注文ありがとうございます
 
-The body of your message.
+この度はご注文いただき、誠にありがとうございます。
+ご注文内容の詳細は以下の通りです。
 
-<x-mail::button :url="''">
-Button Text
-</x-mail::button>
+## ご注文情報
+- **注文コード:** {{ $order->order_code }}
+- **ご注文日時:** {{ $order->created_at->format('Y年m月d日 H:i') }}
+
+## ご注文商品
+<x-mail::table>
+| 商品名 | 数量 |
+| :----- | :--: |
+@if($order->orderDetails && $order->orderDetails->count() > 0)
+@foreach($order->orderDetails as $detail)
+@php
+    $quantity = $detail->quantity ?? 0;
+@endphp
+| {{ $detail->item_name ?? ($detail->item->name ?? 'N/A') }} | {{ $quantity }} |
+@endforeach
+@else
+| 商品情報がありません | - |
+@endif
+</x-mail::table>
+
+今後ともご愛顧賜りますようお願い申し上げます。
 
 Thanks,<br>
 {{ config('app.name') }}

--- a/resources/views/emails/operator/order_notification.blade.php
+++ b/resources/views/emails/operator/order_notification.blade.php
@@ -4,7 +4,7 @@
 新しい注文が入りました。詳細は以下の通りです。
 
 ## 注文情報
-- **注文ID:** {{ $order->id }}
+- **注文コード:** {{ $order->order_code }}
 - **注文日時:** {{ $order->created_at->format('Y年m月d日 H:i') }}
 @if($order->customer)
 - **顧客名:** {{ $order->customer->name ?? 'N/A' }} (ID: {{ $order->customer->id ?? 'N/A' }})
@@ -14,24 +14,19 @@
 
 ## 注文商品
 <x-mail::table>
-| 商品名 | 単価 | 数量 | 小計 |
-| :----- | :---: | :--: | :--: |
+| 商品名 | 数量 |
+| :----- | :--: |
 @if($order->orderDetails && $order->orderDetails->count() > 0)
 @foreach($order->orderDetails as $detail)
 @php
-    $price = $detail->price_at_ordering ?? ($detail->item->price ?? 0);
     $quantity = $detail->quantity ?? 0;
-    $subtotal = $price * $quantity;
 @endphp
-| {{ $detail->item_name ?? ($detail->item->name ?? 'N/A') }} | ¥{{ number_format($price) }} | {{ $quantity }} | ¥{{ number_format($subtotal) }} |
+| {{ $detail->item_name ?? ($detail->item->name ?? 'N/A') }} | {{ $quantity }} |
 @endforeach
 @else
-| 商品情報がありません | - | - | - |
+| 商品情報がありません | - |
 @endif
 </x-mail::table>
-
-## 合計金額
-**¥{{ number_format($order->total_amount ?? 0) }}**
 
 ご確認よろしくお願いいたします。
 


### PR DESCRIPTION
注文お知らせメールのテンプレートを修正しました。

- お客様向けメールと運用者向けメールの両方で、「合計金額」を削除しました。
- 両方のメールで、「注文ID」を「注文コード」に変更し、表示する情報を `$order->order_code` としました。
- 両方のメールの注文商品テーブルから「単価」列と「小計」列を削除しました。
- お客様向けメールの文面を調整し、不要な情報（顧客情報など）を削除しました。