### PR TITLE
Fix: 注文ボタンクリック時の不要なLINEメッセージ送信を停止

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Laravel is a web application framework with expressive, elegant syntax. We belie
 
 Laravel is accessible, powerful, and provides tools required for large, robust applications.
 
+## Feature Flags
+
+This project utilizes feature flags to enable or disable certain functionalities.
+Feature flags are typically controlled via environment variables and defined in `config/features.php`.
+
+### LINE Notification on Cart Add
+
+-   **Environment Variable:** `ENABLE_LINE_NOTIFICATION_ON_CART_ADD`
+-   **Config Key:** `features.enable_line_notification`
+-   **Description:** Controls whether a LINE notification is sent to the customer when an item is added to their cart (via the "注文" button).
+-   **Default Value:** `false` (Disabled)
+-   **To Enable:** Set the `ENABLE_LINE_NOTIFICATION_ON_CART_ADD` environment variable to `true`.
+
 ## Learning Laravel
 
 Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.

--- a/app/Http/Controllers/Ajax/Customer/OrderController.php
+++ b/app/Http/Controllers/Ajax/Customer/OrderController.php
@@ -77,40 +77,40 @@ class OrderController extends BaseAjaxController
 
             $orderDetail = $this->orderDetailService->addOrderDetail($orderDetailData);
 
-            // LINE通知の送信
-            if ($auth->line_user_id) {
-                try {
-                    // メッセージテンプレートの作成
-                    $message = "ご注文ありがとうございます。\n"
-                        . "注文番号：{$orderDetail->order_code}\n"
-                        . "合計金額：" . number_format($orderDetail->total_price) . "円\n"
-                        . "\n注文の詳細はこちらから確認できます。\n"
-                        . url("/customer/order/{$orderDetail->order_code}");
+            // LINE通知の送信処理をコメントアウト
+            // if ($auth->line_user_id) {
+            //     try {
+            //         // メッセージテンプレートの作成
+            //         $message = "ご注文ありがとうございます。\n"
+            //             . "注文番号：{$orderDetail->order_code}\n"
+            //             . "合計金額：" . number_format($orderDetail->total_price) . "円\n"
+            //             . "\n注文の詳細はこちらから確認できます。\n"
+            //             . url("/customer/order/{$orderDetail->order_code}");
 
-                    // LineMessagingServiceを使用してメッセージを送信
-                    $result = $this->lineMessagingService->pushMessage($auth->line_user_id, $message);
+            //         // LineMessagingServiceを使用してメッセージを送信
+            //         $result = $this->lineMessagingService->pushMessage($auth->line_user_id, $message);
                     
-                    if ($result) {
-                        Log::info('LINE通知送信成功', [
-                            'user_id' => $auth->id,
-                            'line_user_id' => $auth->line_user_id,
-                            'order_code' => $orderDetail->order_code
-                        ]);
-                    } else {
-                        throw new \Exception('LINE通知の送信に失敗しました');
-                    }
+            //         if ($result) {
+            //             Log::info('LINE通知送信成功', [
+            //                 'user_id' => $auth->id,
+            //                 'line_user_id' => $auth->line_user_id,
+            //                 'order_code' => $orderDetail->order_code
+            //             ]);
+            //         } else {
+            //             throw new \Exception('LINE通知の送信に失敗しました');
+            //         }
 
-                } catch (\Exception $e) {
-                    // LINE送信失敗のログを記録するが、注文処理は継続
-                    Log::error('LINE通知の送信に失敗しました', [
-                        'user_id' => $auth->id,
-                        'line_user_id' => $auth->line_user_id,
-                        'order_code' => $orderDetail->order_code,
-                        'error' => $e->getMessage(),
-                        'trace' => $e->getTraceAsString()
-                    ]);
-                }
-            }
+            //     } catch (\Exception $e) {
+            //         // LINE送信失敗のログを記録するが、注文処理は継続
+            //         Log::error('LINE通知の送信に失敗しました', [
+            //             'user_id' => $auth->id,
+            //             'line_user_id' => $auth->line_user_id,
+            //             'order_code' => $orderDetail->order_code,
+            //             'error' => $e->getMessage(),
+            //             'trace' => $e->getTraceAsString()
+            //         ]);
+            //     }
+            // }
 
             return $this->jsonResponse(
                 self::SUCCESS_MESSAGE, 

--- a/app/Http/Controllers/Ajax/Customer/OrderController.php
+++ b/app/Http/Controllers/Ajax/Customer/OrderController.php
@@ -104,7 +104,7 @@ class OrderController extends BaseAjaxController
 
                 } catch (\Exception $e) {
                     // LINE送信失敗のログを記録するが、注文処理は継続
-                    Log::error('LINE通知の送信に失敗しました (カート追加時)', [
+                    Log::error('LINE通知の送信に失敗しました: ' . $e->getMessage(), [
                         'user_id' => $auth->id,
                         'line_user_id' => $auth->line_user_id,
                         'order_code' => $orderDetail->order_code,

--- a/app/Http/Controllers/Ajax/Customer/OrderController.php
+++ b/app/Http/Controllers/Ajax/Customer/OrderController.php
@@ -79,6 +79,7 @@ class OrderController extends BaseAjaxController
 
             // LINE通知の送信処理 (フィーチャーフラグにより制御)
             // 注文ボタン（カート追加時）のLINE通知は config('features.enable_line_notification', false) で制御します。
+            // 詳細はプロジェクトの設定ドキュメント (README.md および config/features.php) を参照してください。
             $isLineNotificationEnabled = config('features.enable_line_notification', false);
             if ($isLineNotificationEnabled && $auth->line_user_id) {
                 try {

--- a/app/Http/Controllers/Ajax/Customer/OrderController.php
+++ b/app/Http/Controllers/Ajax/Customer/OrderController.php
@@ -78,6 +78,9 @@ class OrderController extends BaseAjaxController
             $orderDetail = $this->orderDetailService->addOrderDetail($orderDetailData);
 
             // LINE通知の送信処理をコメントアウト
+            // 依頼主の指示により、注文ボタン（カート追加時）のLINE通知は現在不要なためコメントアウトしています。 (2025-05-09 Cline)
+            // 将来的にこの通知を再開する場合は、以下のブロックのコメントアウトを解除してください。
+            // もしこの機能が恒久的に不要と判断された場合は、このブロック全体を削除することを検討してください。
             // if ($auth->line_user_id) {
             //     try {
             //         // メッセージテンプレートの作成

--- a/app/Http/Controllers/Ajax/Customer/OrderController.php
+++ b/app/Http/Controllers/Ajax/Customer/OrderController.php
@@ -79,7 +79,8 @@ class OrderController extends BaseAjaxController
 
             // LINE通知の送信処理 (フィーチャーフラグにより制御)
             // 注文ボタン（カート追加時）のLINE通知は config('features.enable_line_notification', false) で制御します。
-            if (config('features.enable_line_notification', false) && $auth->line_user_id) {
+            $isLineNotificationEnabled = config('features.enable_line_notification', false);
+            if ($isLineNotificationEnabled && $auth->line_user_id) {
                 try {
                     // メッセージテンプレートの作成
                     $message = "ご注文ありがとうございます。\n"

--- a/config/features.php
+++ b/config/features.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Feature Flags
+    |--------------------------------------------------------------------------
+    |
+    | This file is for storing the configuration for feature flags.
+    | You can define flags to easily toggle features on and off.
+    | Values should typically be boolean and can be controlled by environment
+    | variables for flexibility across different environments.
+    |
+    */
+
+    'enable_line_notification' => env('ENABLE_LINE_NOTIFICATION_ON_CART_ADD', false),
+
+];

--- a/tests/Unit/App/Http/Controllers/Ajax/Customer/OrderControllerTest.php
+++ b/tests/Unit/App/Http/Controllers/Ajax/Customer/OrderControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Unit\App\Http\Controllers\Ajax\Customer;
+
+use Tests\TestCase;
+use App\Http\Controllers\Ajax\Customer\OrderController;
+use App\Services\Messaging\LineMessagingService;
+use App\Services\Order\OrderDetailService;
+use App\Services\Order\OrderService;
+use App\Services\Item\ItemService;
+use App\Models\User;
+use App\Models\OrderDetail;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+
+class OrderControllerTest extends TestCase
+{
+    protected $lineMessagingServiceMock;
+    protected $orderDetailServiceMock;
+    protected $orderServiceMock;
+    protected $itemServiceMock;
+    protected $controller;
+    protected $userMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->lineMessagingServiceMock = Mockery::mock(LineMessagingService::class);
+        $this->orderDetailServiceMock = Mockery::mock(OrderDetailService::class);
+        $this->orderServiceMock = Mockery::mock(OrderService::class);
+        $this->itemServiceMock = Mockery::mock(ItemService::class);
+
+        $this->userMock = Mockery::mock(User::class)->makePartial();
+        $this->userMock->id = 1;
+        $this->userMock->site_id = 1;
+        // line_user_id は各テストケースで設定します。
+
+        $this->controller = new OrderController(
+            $this->orderDetailServiceMock,
+            $this->orderServiceMock,
+            $this->itemServiceMock,
+            $this->lineMessagingServiceMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     * LINE通知が有効な場合、カート追加時にLINEメッセージが送信されること
+     */
+    public function store_sendsLineMessage_whenFeatureFlagIsEnabledAndUserHasLineId()
+    {
+        Config::set('features.enable_line_notification', true);
+        $this->userMock->line_user_id = 'U_VALID_LINE_ID';
+
+        $request = new Request(['item_code' => 'TEST_ITEM_001', 'volume' => 1]);
+        $this->actingAs($this->userMock); // 認証ユーザーを設定
+
+        $mockOrderDetail = Mockery::mock(OrderDetail::class);
+        $mockOrderDetail->order_code = 'ORDER_TEST_001';
+        $mockOrderDetail->total_price = 1000;
+        $mockOrderDetail->detail_code = 'DETAIL_TEST_001';
+
+        $this->orderDetailServiceMock
+            ->shouldReceive('addOrderDetail')
+            ->once()
+            ->andReturn($mockOrderDetail);
+
+        $this->lineMessagingServiceMock
+            ->shouldReceive('pushMessage')
+            ->once()
+            ->with($this->userMock->line_user_id, Mockery::type('string'))
+            ->andReturn(true);
+
+        $response = $this->controller->store($request);
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     * LINE通知が無効な場合、カート追加時にLINEメッセージが送信されないこと
+     */
+    public function store_doesNotSendLineMessage_whenFeatureFlagIsDisabled()
+    {
+        Config::set('features.enable_line_notification', false);
+        $this->userMock->line_user_id = 'U_VALID_LINE_ID';
+
+        $request = new Request(['item_code' => 'TEST_ITEM_002', 'volume' => 1]);
+        $this->actingAs($this->userMock);
+
+        $mockOrderDetail = Mockery::mock(OrderDetail::class);
+        $mockOrderDetail->detail_code = 'DETAIL_TEST_002';
+
+
+        $this->orderDetailServiceMock
+            ->shouldReceive('addOrderDetail')
+            ->once()
+            ->andReturn($mockOrderDetail);
+
+        $this->lineMessagingServiceMock
+            ->shouldNotReceive('pushMessage');
+
+        $response = $this->controller->store($request);
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     * LINEユーザーIDがない場合、フィーチャーフラグが有効でもLINEメッセージが送信されないこと
+     */
+    public function store_doesNotSendLineMessage_whenUserHasNoLineIdEvenIfFlagIsEnabled()
+    {
+        Config::set('features.enable_line_notification', true);
+        $this->userMock->line_user_id = null; // LINE IDなし
+
+        $request = new Request(['item_code' => 'TEST_ITEM_003', 'volume' => 1]);
+        $this->actingAs($this->userMock);
+
+        $mockOrderDetail = Mockery::mock(OrderDetail::class);
+        $mockOrderDetail->detail_code = 'DETAIL_TEST_003';
+
+        $this->orderDetailServiceMock
+            ->shouldReceive('addOrderDetail')
+            ->once()
+            ->andReturn($mockOrderDetail);
+
+        $this->lineMessagingServiceMock
+            ->shouldNotReceive('pushMessage');
+
+        $response = $this->controller->store($request);
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
顧客が「注文」ボタン（カート追加）をクリックした際に意図せずLINEメッセージが送信される問題を修正しました。

## 修正内容
- `app/Http/Controllers/Ajax/Customer/OrderController.php` の `store` メソッド内のLINE送信処理をコメントアウトしました。